### PR TITLE
11 dodanie funkcjonalności do surreal orm

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 
+from app.trees import get_tree_router
+
 from .users import (
     UserRead,
     UserCreate,
@@ -27,3 +29,5 @@ app.include_router(
     prefix="/api/users",
     tags=["users"],
 )
+
+app.include_router(get_tree_router(fastapi_users), prefix="/api/trees", tags=["data"])

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from app.node import get_node_router
 
 from app.trees import get_tree_router
 
@@ -31,3 +32,5 @@ app.include_router(
 )
 
 app.include_router(get_tree_router(fastapi_users), prefix="/api/trees", tags=["data"])
+
+app.include_router(get_node_router(fastapi_users), prefix="/api/nodes", tags=["data"])

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from app.node import get_node_router
 
 from app.trees import get_tree_router
@@ -31,6 +32,17 @@ app.include_router(
     tags=["users"],
 )
 
-app.include_router(get_tree_router(fastapi_users), prefix="/api/trees", tags=["data"])
+app.include_router(
+    get_tree_router(fastapi_users), prefix="/api/trees", tags=["data"]
+)
 
-app.include_router(get_node_router(fastapi_users), prefix="/api/nodes", tags=["data"])
+app.include_router(
+    get_node_router(fastapi_users), prefix="/api/nodes", tags=["data"]
+)
+
+
+@app.get("/", response_class=RedirectResponse)
+def redirect_to_docs():
+    """Redirects the developer to the docs, if they forget to add `/docs` to
+    the url."""
+    return RedirectResponse("/docs")

--- a/backend/app/node.py
+++ b/backend/app/node.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, Depends, HTTPException
+import asyncio
+from typing import Dict
+from fastapi_users import FastAPIUsers
+
+from app.surreal_orm import get_db
+from app.users import UserRead
+
+from .surreal_orm.session import Session
+from .tables import Node, NodeRelation
+
+
+def get_node_router(fastapi_users: FastAPIUsers) -> APIRouter:
+    router = APIRouter()
+
+    @router.post("/new", response_model=Node)
+    async def create_new_node(
+        tree_id: str,
+        node_props: Dict,
+        session: Session = Depends(get_db),
+        current_user: UserRead = Depends(fastapi_users.current_user()),
+    ):
+        if tree_id not in current_user.trees:
+            raise HTTPException(403)
+
+        node, tree = await asyncio.gather(
+            session.Node.create(props=node_props),
+            session.Tree.select_deep(tree_id, ["nodes"]),
+        )
+
+        await session.Tree.patch(tree.id, nodes=[*tree.nodes, node])
+
+        return node
+
+    @router.post(
+        "/relation/{tree_id}/link/{in_node_id}/{out_node_id}",
+        response_model=NodeRelation,
+    )
+    async def link_nodes(
+        tree_id: str,
+        in_node_id: str,
+        out_node_id: str,
+        edge_props: Dict,
+        relation_type: str,
+        session: Session = Depends(get_db),
+        current_user: UserRead = Depends(fastapi_users.current_user()),
+    ):
+        if tree_id not in current_user.trees:
+            raise HTTPException(403)
+
+        tree = await session.Tree.select_id(tree_id)
+        if in_node_id not in tree.nodes or out_node_id not in tree.nodes:
+            raise HTTPException(400, "Nodes don't belong to the same tree")
+
+        return await session.NodeRelation.create(
+            in_node_id, out_node_id, props=edge_props, relation_type=relation_type
+        )
+
+    return router

--- a/backend/app/node.py
+++ b/backend/app/node.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 import asyncio
-from typing import Dict
+from typing import Dict, List
 from fastapi_users import FastAPIUsers
 
 from app.surreal_orm import get_db
@@ -8,12 +8,13 @@ from app.users import UserRead
 
 from .surreal_orm.session import Session
 from .tables import Node, NodeRelation
+from app.surreal_orm import session
 
 
 def get_node_router(fastapi_users: FastAPIUsers) -> APIRouter:
     router = APIRouter()
 
-    @router.post("/new", response_model=Node)
+    @router.post("/new/{tree_id}", response_model=Node)
     async def create_new_node(
         tree_id: str,
         node_props: Dict,
@@ -53,7 +54,28 @@ def get_node_router(fastapi_users: FastAPIUsers) -> APIRouter:
             raise HTTPException(400, "Nodes don't belong to the same tree")
 
         return await session.NodeRelation.create(
-            in_node_id, out_node_id, props=edge_props, relation_type=relation_type
+            in_node_id,
+            out_node_id,
+            props=edge_props,
+            relation_type=relation_type,
         )
+
+    @router.get(
+        "/relations/{tree_id}/{node_id}", response_model=List[NodeRelation]
+    )
+    async def get_relations_for_node(
+        tree_id: str,
+        node_id: str,
+        session: Session = Depends(get_db),
+        current_user: UserRead = Depends(fastapi_users.current_user()),
+    ):
+        if tree_id not in current_user.trees:
+            raise HTTPException(403)
+
+        tree = await session.Tree.select_id(tree_id)
+        if node_id not in tree.nodes:
+            raise HTTPException(400, "Node does not belong to the given tree!")
+
+        return await session.Node.select_related(node_id, NodeRelation)
 
     return router

--- a/backend/app/surreal_orm/README.md
+++ b/backend/app/surreal_orm/README.md
@@ -30,7 +30,7 @@ from surreal_orm import get_db
 
 async def create_example():
     # Create a session for the database operations
-    session = get_db()
+    session = await get_db()
 
     # properties are given as key word arguments. A table is selected 
     # as a attribiute of the session object.
@@ -40,6 +40,9 @@ async def create_example():
         "foo", 
         field="this record has the `foo` id"
     )
+
+    # Commit the transaction
+    await session.commit()
 ```
 
 ### `SELECT` statements:
@@ -49,7 +52,7 @@ from surreal_orm import get_db
 
 async def select_example():
     # Create a session for the database operations
-    session = get_db()
+    session = await get_db()
 
     all_examples = await session.Example.select_all()
     
@@ -120,7 +123,7 @@ As a result, the `create` operation requires those parameters.
 
 ```python
 async def create_relation():
-    session = get_db()
+    session = await get_db()
 
     # let `chad` be a person with a random id
     chad = await session.Person.create(name="Chad")
@@ -131,6 +134,8 @@ async def create_relation():
     # chad drove the miata for 5 football fields, 
     # you can pass full objects or raw ids to the function
     trip = await session.Trip.create(chad, 'Car:miata', distance=5)
+
+    await session.commit()
 ```
 
 You can also query all the relations that come out from a given object using the
@@ -155,21 +160,9 @@ aliased as `in_` as `in` is a python keyword
 
 ## Caveats
 
-### SurrealDB ids
+### Transactions:
 
-```
-<table_name>:<item_id>
-
--- Structure of SurrealDB ids
-```
-
-The `surreal.py` wrapper sometimes expects only the `item` part of the id to 
-be present. As a result `surrealORM` will attempt to strip the **table_name**
-part of the id automatically.
-
-A partial id, consisting only of an `item_id` will still work, but a full id is 
-preferred.
-
+Transactions are currently broken and do not rollback the data.
 
 ### `base` and `Base`
 

--- a/backend/app/surreal_orm/README.md
+++ b/backend/app/surreal_orm/README.md
@@ -1,0 +1,150 @@
+# surrealORM
+
+A simple wrapper over the `surreal.py` client based on pydantic.
+
+
+## Capabilities:
+
+- Table definitions
+- Edge definitions
+- basic CRUD
+
+## Table operations:
+
+A table can be defined using the following code:
+
+```python
+from pydantic import BaseModel
+from surreal_orm import base 
+
+@base.table 
+class Example(BaseModel):
+    # define table fields just like on the pydantic models
+    field: str
+```
+
+### Object creation:
+
+```python
+from surreal_orm import get_db
+
+async def create_example():
+    # Create a session for the database operations
+    session = get_db()
+
+    # properties are given as key word arguments. A table is selected 
+    # as a attribiute of the session object.
+    result = await session.Example.create(field="value")
+
+    named_result = await session.Example.create_one(
+        "foo", 
+        field="this record has the `foo` id"
+    )
+```
+
+### `SELECT` statements:
+
+```python
+from surreal_orm import get_db
+
+async def select_example():
+    # Create a session for the database operations
+    session = get_db()
+
+    all_examples = await session.Example.select_all()
+    
+    # Conditional selections, that automatically fill in the WHERE clause
+    conditional_selections = await session.Example.select("field = {}", ("foo"))
+```
+
+### Record links:
+
+Record links can be defined like so:
+
+```python
+from surreal_orm import Relation
+
+@base.table
+class Tutorial(BaseModel):
+    an_example: Relation[Example]
+
+```
+
+By default all record links are fetched as string ids, but you can use the 
+`select_deep` operation to fetch them.
+
+```
+tutorials_with_examples = await session.Tutorial.select_deep("an_id", ['an_example'])
+```
+
+### Implied fields:
+
+`surreal_orm` will automatically add an `id` field with type `str` for every 
+table. It will hold the `id` from SurrealDB and will effectively function as a 
+primary key.
+
+## Graph operations:
+
+Graph operations are very similar compared to table operations, every graph 
+is effectively a table with a fancy `CREATE` method.
+
+```python
+@base.table
+class Person(BaseModel):
+    name: str
+
+@base.table
+class Car(BaseModel):
+    marque: str
+
+
+# This class will represent the `Person->Car` edge.
+@base.relation(Person, Car)
+class Trip(BaseModel):
+    distance: int
+
+```
+
+### Creation:
+
+When creating a relation, we need to specify the `in` or `from` object/id and 
+the `out` or `to` object/id. A look at the figure below might be helpful.
+
+```
+[Person] from ---> in [Trip] out ---> to [CAR]
+```
+
+As a result, the `create` operation requires those parameters.
+
+```python
+async def create_relation():
+    session = get_db()
+
+    # let `chad` be a person with a random id
+    chad = await session.Person.create(name="Chad")
+
+    # let `miata` have an id of `Car:miata`
+    miata = await session.Car.create_one('miata', name="Madzia")
+
+    # chad drove the miata for 5 football fields, 
+    # you can pass full objects or raw ids to the function
+    trip = await session.Trip.create(chad, 'Car:miata', distance=5)
+```
+
+You can also query all the relations that come out from a given object using the
+`select_related` method:
+
+```python
+async def select_driven_cars():
+    session = get_db()
+
+    # Return all `Trip`s that a person with id `chad` traveled. This method 
+    # also fetches all the `Car`s 
+    trips = await session.Person.select_related('chad', Drove)
+```
+
+### Implied fields:
+
+`surreal_orm` will also add the following fields to your models:
+- `id: str` - id of the edge
+- `out: Relation[T]` - a string id or object  

--- a/backend/app/surreal_orm/README.md
+++ b/backend/app/surreal_orm/README.md
@@ -112,6 +112,8 @@ the `out` or `to` object/id. A look at the figure below might be helpful.
 
 ```
 [Person] from ---> in [Trip] out ---> to [CAR]
+
+-- Diagram of terminology used with graph edges
 ```
 
 As a result, the `create` operation requires those parameters.
@@ -147,4 +149,29 @@ async def select_driven_cars():
 
 `surreal_orm` will also add the following fields to your models:
 - `id: str` - id of the edge
-- `out: Relation[T]` - a string id or object  
+- `out: Relation[T]` - a string id or object that is a part of the graph edge
+- `in: Relation[T]` - a string id or object that is a part of the graph edge, also 
+aliased as `in_` as `in` is a python keyword
+
+## Caveats
+
+### SurrealDB ids
+
+```
+<table_name>:<item_id>
+
+-- Structure of SurrealDB ids
+```
+
+The `surreal.py` wrapper sometimes expects only the `item` part of the id to 
+be present. As a result `surrealORM` will attempt to strip the **table_name**
+part of the id automatically.
+
+A partial id, consisting only of an `item_id` will still work, but a full id is 
+preferred.
+
+
+### `base` and `Base`
+
+It is recommended to keep your schema definitions in one file. The ORM provides 
+a `base` object of class `Base` that is used to keep track of all table definitions.

--- a/backend/app/surreal_orm/__init__.py
+++ b/backend/app/surreal_orm/__init__.py
@@ -8,14 +8,16 @@ from .session import Session
 async def get_db() -> AsyncGenerator[Session, None]:
     async with WebsocketClient(
         f"http://{environ.get('DATABASE', 'localhost:8001')}/rpc",
-    ) as client: 
-        await client.signin({
-            'user': 'root',
-            'pass': 'root',
-        })
+    ) as client:
+        await client.signin(
+            {
+                "user": "root",
+                "pass": "root",
+            }
+        )
         # Specify the namespace and the database
-        await client.use('test', 'test')
-        await client.query('BEGIN TRANSACTION;')
+        await client.use("test", "test")
+        await client.query("BEGIN TRANSACTION;")
 
         # Create a database session and do stuff
         session = Session(client, base)
@@ -23,7 +25,4 @@ async def get_db() -> AsyncGenerator[Session, None]:
 
         # If we did not commit the data, cancel the transaction
         if not session._commited:
-            await client.query('CANCEL TRANSACTION;')
-
-
-
+            await client.query("CANCEL TRANSACTION;")

--- a/backend/app/surreal_orm/__init__.py
+++ b/backend/app/surreal_orm/__init__.py
@@ -1,15 +1,29 @@
 from os import environ
-from surrealdb.clients import HTTPClient
+from typing import AsyncGenerator
+from surrealdb.clients import WebsocketClient
 from .base import base
 from .session import Session
 
 
-def get_db() -> Session:
-    client = HTTPClient(
-        f"http://{environ.get('DATABASE', 'localhost:8001')}",
-        namespace="test",
-        database="test",
-        username="root",
-        password="root",
-    )
-    return Session(client, base)
+async def get_db() -> AsyncGenerator[Session, None]:
+    async with WebsocketClient(
+        f"http://{environ.get('DATABASE', 'localhost:8001')}/rpc",
+    ) as client: 
+        await client.signin({
+            'user': 'root',
+            'pass': 'root',
+        })
+        # Specify the namespace and the database
+        await client.use('test', 'test')
+        await client.query('BEGIN TRANSACTION;')
+
+        # Create a database session and do stuff
+        session = Session(client, base)
+        yield session
+
+        # If we did not commit the data, cancel the transaction
+        if not session._commited:
+            await client.query('CANCEL TRANSACTION;')
+
+
+

--- a/backend/app/surreal_orm/base.py
+++ b/backend/app/surreal_orm/base.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List, Tuple, Optional
-from surrealdb.clients import HTTPClient
+from pydantic import BaseModel
+from .tables import get_table_class, get_relation_class
+
 
 from app.utils import debug
 from .utils import (
     quote_param,
-    get_surreal_id_fuckery_normalizer,
     change_data_to_relation,
 )
 
@@ -17,108 +17,23 @@ class Base:
     def __init__(self) -> None:
         self.tables = {}
 
-    def table(self, pydantic_class: Any):
+    def edge(self, from_class: type[BaseModel], to_class: type[BaseModel]):
+        def inner(pydantic_class: type[BaseModel]):
 
-        id_normalizer = get_surreal_id_fuckery_normalizer(pydantic_class.__name__)
+            RelationTable, RelationEntry = get_relation_class(
+                from_class, to_class, pydantic_class
+            )
 
-        class TableEntry(pydantic_class):
-            id: str
+            # Register the table with the rest
+            self.tables[pydantic_class.__name__] = RelationTable
 
-        # Change the name of the TableEntry class to the original name
-        TableEntry.__name__ = pydantic_class.__name__
-        TableEntry.__doc__ = pydantic_class.__doc__
+            return RelationEntry
 
-        class Table:
-            __name = pydantic_class.__name__
+        return inner
 
-            def __init__(self, db_client: HTTPClient) -> None:
-                self._client = db_client
+    def table(self, pydantic_class: type[BaseModel]):
 
-            async def create(self, **data: Dict) -> TableEntry:
-                """Creates an object from kwargs with random id and stores it
-                in surrealdb"""
-                return TableEntry(
-                    **(
-                        await self._client.create_all(
-                            self.__name, change_data_to_relation(data)
-                        )
-                    )[0]
-                )
-
-            async def create_one(self, id: str, **data: Dict) -> TableEntry:
-                """Creates an object from kwargs with given id and stores it in
-                surrealdb"""
-                return TableEntry(
-                    **await self._client.create_one(
-                        self.__name, id_normalizer(id), change_data_to_relation(data)
-                    )
-                )
-
-            async def select(
-                self, where_args: str, where_params: Optional[Tuple] = None
-            ) -> List[TableEntry]:
-                """Returns rows that match the where clause"""
-                if where_params is None:
-                    where_params = tuple()
-                else:
-                    where_params = tuple([quote_param(param) for param in where_params])
-                return list(
-                    TableEntry(**d)
-                    for d in await self._client.execute(
-                        f"SELECT * FROM {self.__name} WHERE {where_args}".format(
-                            *where_params
-                        )
-                    )
-                )
-
-            async def select_deep(
-                self, id: str, fields_to_fetch: List[str]
-            ) -> TableEntry:
-                """Returns an object with given id with all it's links loaded"""
-                result = await self._client.execute(
-                    f'SELECT * FROM {id} FETCH {",".join(fields_to_fetch)}'
-                )
-                if len(result) != 1:
-                    raise Exception("Failed to fetch by id!")
-                return TableEntry(**result[0])
-
-            async def select_all(self) -> List[TableEntry]:
-                """Returns all rows from the table"""
-                response = await self._client.select_all(self.__name)
-                return list(TableEntry(**d) for d in response)
-
-            async def select_id(self, id: str) -> TableEntry:
-                """Selects a record with a given id"""
-                return TableEntry(
-                    **await self._client.select_one(self.__name, id_normalizer(id))
-                )
-
-            async def replace(self, id: str, **new_data: Dict) -> TableEntry:
-                """Replaces all data with a given id with new id"""
-                return TableEntry(
-                    **await self._client.replace_one(
-                        self.__name,
-                        id_normalizer(id),
-                        change_data_to_relation(new_data),
-                    )
-                )
-
-            async def patch(self, id: str, **fields_to_replace: Dict) -> TableEntry:
-                """Patches some fields with a given id, a partial replace"""
-                return TableEntry(
-                    **await self._client.upsert_one(
-                        self.__name,
-                        id_normalizer(id),
-                        change_data_to_relation(fields_to_replace),
-                    )
-                )
-
-            async def delete(self, id: str):
-                """Deletes an item with a given id from the table"""
-                await self._client.delete_one(self.__name, id_normalizer(id))
-
-        # When debuging tables show the appropriate name
-        Table.__name__ = f"{pydantic_class.__name__}Table"
+        Table, TableEntry = get_table_class(pydantic_class)
 
         # Register the table with the rest
         self.tables[pydantic_class.__name__] = Table

--- a/backend/app/surreal_orm/relation.py
+++ b/backend/app/surreal_orm/relation.py
@@ -1,0 +1,6 @@
+from typing import Generic, TypeVar, Union, List
+
+T = TypeVar("T")
+
+Relation = Union[T, str]
+RelationList = Union[List[T], List[str]]

--- a/backend/app/surreal_orm/session.py
+++ b/backend/app/surreal_orm/session.py
@@ -13,6 +13,8 @@ class Session:
         self._client = client
         self._base = base
 
-    def __getattr__(self, __name: str) -> Union[TableInterface, RelationTableInterface]:
+    def __getattr__(
+        self, __name: str
+    ) -> Union[TableInterface, RelationTableInterface]:
         """Returns appropriate table as a property of this session"""
         return self._base.tables[__name](self._client)

--- a/backend/app/surreal_orm/session.py
+++ b/backend/app/surreal_orm/session.py
@@ -1,4 +1,4 @@
-from surrealdb.clients import HTTPClient
+from surrealdb.clients import WebsocketClient
 from typing import Union
 
 from .tables import TableInterface, RelationTableInterface
@@ -9,12 +9,19 @@ class Session:
     """Class that contains the connection to surrealdb and allows operations
     on tables"""
 
-    def __init__(self, client: HTTPClient, base: Base) -> None:
+    def __init__(self, client: WebsocketClient, base: Base) -> None:
         self._client = client
         self._base = base
+        self._commited = False
 
     def __getattr__(
         self, __name: str
     ) -> Union[TableInterface, RelationTableInterface]:
         """Returns appropriate table as a property of this session"""
         return self._base.tables[__name](self._client)
+
+    async def commit(self):
+        """Commits the transaction"""
+        await self._client.query('COMMIT TRANSACTION')
+        self._commited = True
+        

--- a/backend/app/surreal_orm/session.py
+++ b/backend/app/surreal_orm/session.py
@@ -1,5 +1,7 @@
 from surrealdb.clients import HTTPClient
-from typing import Any
+from typing import Union
+
+from .tables import TableInterface, RelationTableInterface
 from .base import Base
 
 
@@ -11,6 +13,6 @@ class Session:
         self._client = client
         self._base = base
 
-    def __getattr__(self, __name: str) -> Any:
+    def __getattr__(self, __name: str) -> Union[TableInterface, RelationTableInterface]:
         """Returns appropriate table as a property of this session"""
         return self._base.tables[__name](self._client)

--- a/backend/app/surreal_orm/session.py
+++ b/backend/app/surreal_orm/session.py
@@ -22,6 +22,5 @@ class Session:
 
     async def commit(self):
         """Commits the transaction"""
-        await self._client.query('COMMIT TRANSACTION')
+        await self._client.query("COMMIT TRANSACTION")
         self._commited = True
-        

--- a/backend/app/surreal_orm/tables.py
+++ b/backend/app/surreal_orm/tables.py
@@ -12,24 +12,41 @@ from .utils import (
 )
 
 T = TypeVar("T", covariant=True)
+R = TypeVar("R")
 
 
 class TableInterface(Protocol[T]):
+    """Defines all the operations a table should have"""
+
     async def create(self, **data: Dict) -> T:
         raise NotImplemented()
 
     async def select(
-        self, where_args: str, where_params: Optional[Tuple] = None
+        self,
+        where_args: str,
+        where_params: Optional[Tuple] = None,
+        fields_to_fetch: Optional[List[str]] = None,
     ) -> List[T]:
         raise NotImplemented()
 
     async def select_deep(self, id: str, fields_to_fetch: List[str]) -> T:
+        """
+        Record link relations need to be fetched explicitly, otherwise
+        they will be available only as strings.
+        """
         raise NotImplemented()
 
     async def select_all(self) -> List[T]:
         raise NotImplemented()
 
     async def select_id(self, id: str) -> T:
+        raise NotImplemented()
+
+    async def select_related(self, id: str, relation: type[R]) -> List[R]:
+        """
+        Selects all the outgoing edges and their targets that belong to a
+        given `relation` relation.
+        """
         raise NotImplemented()
 
     async def replace(self, id: str, **new_data: Dict) -> T:
@@ -47,6 +64,8 @@ T_out = TypeVar("T_out", covariant=True)
 
 
 class RelationTableInterface(Protocol[T, T_in, T_out]):
+    """Defines all the operations a relation table should have"""
+
     async def create(
         self,
         from_obj: Union[T_in, str],
@@ -56,21 +75,18 @@ class RelationTableInterface(Protocol[T, T_in, T_out]):
         raise NotImplemented()
 
     async def select(
-        self, where_args: str, where_params: Optional[Tuple] = None
+        self,
+        where_args: str,
+        where_params: Optional[Tuple] = None,
+        fields_to_fetch: Optional[List[str]] = None,
     ) -> List[T]:
         raise NotImplemented()
 
-    async def select_in(
-        self, where_args: str, where_params: Optional[Tuple] = None
-    ) -> List[T_in]:
-        raise NotImplemented()
-
-    async def select_out(
-        self, where_args: str, where_params: Optional[Tuple] = None
-    ) -> List[T_out]:
-        raise NotImplemented()
-
     async def select_deep(self, id: str, fields_to_fetch: List[str]) -> T:
+        """
+        Record link relations need to be fetched explicitly, otherwise
+        they will be available only as strings.
+        """
         raise NotImplemented()
 
     async def select_all(self) -> List[T]:
@@ -130,30 +146,53 @@ def get_table_class(
             )
 
         async def select(
-            self, where_args: str, where_params: Optional[Tuple] = None
+            self,
+            where_args: str,
+            where_params: Optional[Tuple] = None,
+            fields_to_fetch: Optional[List[str]] = None,
         ) -> List[TableEntry]:
             """Returns rows that match the where clause"""
             if where_params is None:
                 where_params = tuple()
             else:
-                where_params = tuple([quote_param(param) for param in where_params])
+                where_params = tuple(
+                    [quote_param(param) for param in where_params]
+                )
+            if fields_to_fetch is None:
+                fetch_statement = ""
+            else:
+                fetch_statement = f"FETCH {', '.join(fields_to_fetch)}"
             return list(
                 TableEntry(**d)
                 for d in await self._client.execute(
-                    f"SELECT * FROM {self.__name} WHERE {where_args}".format(
+                    f"SELECT * FROM {self.__name} WHERE {where_args} {fetch_statement}".format(
                         *where_params
                     )
                 )
             )
 
-        async def select_deep(self, id: str, fields_to_fetch: List[str]) -> TableEntry:
+        async def select_deep(
+            self, id: str, fields_to_fetch: List[str]
+        ) -> TableEntry:
             """Returns an object with given id with all it's links loaded"""
             result = await self._client.execute(
-                f'SELECT * FROM {id} FETCH {",".join(fields_to_fetch)}'
+                f'SELECT * FROM {quote_param(id)} FETCH {",".join(fields_to_fetch)}'
             )
             if len(result) != 1:
                 raise Exception("Failed to fetch by id!")
             return TableEntry(**result[0])
+
+        async def select_related(self, id: str, relation: type[R]) -> List[R]:
+            """Selects given relations (edges) that come out of the given
+            id"""
+            # quote item id, to hopefully prevent SQL injection
+            item_id = quote_param(f"{self.__name}:{id_normalizer(id)}")
+            result = await self._client.execute(
+                f"SELECT ->{relation.__name__}.* AS rel FROM {item_id} FETCH rel.out"
+            )
+            if len(result) != 1:
+                raise Exception("Failed to fetch by id!")
+            return list(relation(**x) for x in result[0]["rel"])
 
         async def select_all(self) -> List[TableEntry]:
             """Returns all rows from the table"""
@@ -190,7 +229,7 @@ def get_table_class(
             """Deletes an item with a given id from the table"""
             await self._client.delete_one(self.__name, id_normalizer(id))
 
-    # When debuging tables show the appropriate name
+    # When debugging tables show the appropriate name
     Table.__name__ = f"{pydantic_class.__name__}Table"
 
     return Table, TableEntry
@@ -219,11 +258,16 @@ def get_relation_class(
             to_obj: Union[to_class, str],
             **data: Dict,
         ) -> RelationEntry:
+            """Creates a relation using the `RELATE` statement"""
             res = await self._client.execute(
                 "RELATE {}->{}->{} CONTENT {}".format(
-                    from_obj if isinstance(from_obj, str) else from_obj.id,
+                    quote_param(
+                        from_obj if isinstance(from_obj, str) else from_obj.id
+                    ),
                     self.__name,
-                    to_obj if isinstance(to_obj, str) else to_obj.id,
+                    quote_param(
+                        to_obj if isinstance(to_obj, str) else to_obj.id
+                    ),
                     dumps(change_data_to_relation(data)),
                 ),
             )
@@ -231,5 +275,7 @@ def get_relation_class(
             if len(res) != 1:
                 raise Exception("Failed to create relation")
             return RelationEntry(**res[0])
+
+    RelationEntry.__name__ = pydantic_class.__name__
 
     return RelationTable, RelationEntry

--- a/backend/app/surreal_orm/tables.py
+++ b/backend/app/surreal_orm/tables.py
@@ -107,7 +107,6 @@ class RelationTableInterface(Protocol[T, T_in, T_out]):
 def get_table_class(
     pydantic_class: type[BaseModel],
 ) -> Tuple[type[TableInterface], type[BaseModel]]:
-
     class TableEntry(pydantic_class):
         id: str
 
@@ -124,11 +123,9 @@ def get_table_class(
             """Creates an object from kwargs with random id and stores it
             in surrealdb"""
             result = await self._client.create(
-                        self.__name, change_data_to_relation(data)
-                    ) 
-            return TableEntry(
-                **result[0]
+                self.__name, change_data_to_relation(data)
             )
+            return TableEntry(**result[0])
 
         async def select(
             self,
@@ -148,14 +145,11 @@ def get_table_class(
             else:
                 fetch_statement = f"FETCH {', '.join(fields_to_fetch)}"
             result = await self._client.query(
-                    f"SELECT * FROM {self.__name} WHERE {where_args} {fetch_statement}".format(
-                        *where_params
-                    )
+                f"SELECT * FROM {self.__name} WHERE {where_args} {fetch_statement}".format(
+                    *where_params
                 )
-            return list(
-                TableEntry(**d)
-                for d in result[0]
             )
+            return list(TableEntry(**d) for d in result[0])
 
         async def select_deep(
             self, id: str, fields_to_fetch: List[str]
@@ -190,29 +184,23 @@ def get_table_class(
         async def select_id(self, id: str) -> TableEntry:
             """Selects a record with a given id"""
             res = await self._client.select(id)
-            return TableEntry(
-                **res[0]
-            )
+            return TableEntry(**res[0])
 
         async def replace(self, id: str, **new_data: Dict) -> TableEntry:
             """Replaces all data with a given id with new id"""
             res = await self._client.update(
-                    id,
-                    change_data_to_relation(new_data),
-                )
-            return TableEntry(
-                **res[0]
+                id,
+                change_data_to_relation(new_data),
             )
+            return TableEntry(**res[0])
 
         async def patch(self, id: str, **fields_to_replace: Dict) -> TableEntry:
             """Patches some fields with a given id, a partial replace"""
             res = await self._client.change(
-                    id,
-                    change_data_to_relation(fields_to_replace),
-                )
-            return TableEntry(
-                **res[0]
+                id,
+                change_data_to_relation(fields_to_replace),
             )
+            return TableEntry(**res[0])
 
         async def delete(self, id: str):
             """Deletes an item with a given id from the table"""

--- a/backend/app/surreal_orm/tables.py
+++ b/backend/app/surreal_orm/tables.py
@@ -1,0 +1,235 @@
+from surrealdb.common.json import dumps
+from pydantic import BaseModel, Field
+from surrealdb.clients import HTTPClient
+from typing import Dict, Protocol, Tuple, Optional, List, TypeVar, Union
+
+from app.surreal_orm.relation import Relation
+from .utils import (
+    change_data_to_relation,
+    get_surreal_id_fuckery_normalizer,
+    quote_param,
+    change_data_to_relation,
+)
+
+T = TypeVar("T", covariant=True)
+
+
+class TableInterface(Protocol[T]):
+    async def create(self, **data: Dict) -> T:
+        raise NotImplemented()
+
+    async def select(
+        self, where_args: str, where_params: Optional[Tuple] = None
+    ) -> List[T]:
+        raise NotImplemented()
+
+    async def select_deep(self, id: str, fields_to_fetch: List[str]) -> T:
+        raise NotImplemented()
+
+    async def select_all(self) -> List[T]:
+        raise NotImplemented()
+
+    async def select_id(self, id: str) -> T:
+        raise NotImplemented()
+
+    async def replace(self, id: str, **new_data: Dict) -> T:
+        raise NotImplemented()
+
+    async def patch(self, id: str, **fields_to_replace: Dict) -> T:
+        raise NotImplemented()
+
+    async def delete(self, id: str):
+        raise NotImplemented()
+
+
+T_in = TypeVar("T_in", covariant=True)
+T_out = TypeVar("T_out", covariant=True)
+
+
+class RelationTableInterface(Protocol[T, T_in, T_out]):
+    async def create(
+        self,
+        from_obj: Union[T_in, str],
+        to_obj: Union[T_out, str],
+        **data: Dict,
+    ) -> T:
+        raise NotImplemented()
+
+    async def select(
+        self, where_args: str, where_params: Optional[Tuple] = None
+    ) -> List[T]:
+        raise NotImplemented()
+
+    async def select_in(
+        self, where_args: str, where_params: Optional[Tuple] = None
+    ) -> List[T_in]:
+        raise NotImplemented()
+
+    async def select_out(
+        self, where_args: str, where_params: Optional[Tuple] = None
+    ) -> List[T_out]:
+        raise NotImplemented()
+
+    async def select_deep(self, id: str, fields_to_fetch: List[str]) -> T:
+        raise NotImplemented()
+
+    async def select_all(self) -> List[T]:
+        raise NotImplemented()
+
+    async def select_id(self, id: str) -> T:
+        raise NotImplemented()
+
+    async def replace(self, id: str, **new_data: Dict) -> T:
+        raise NotImplemented()
+
+    async def patch(self, id: str, **fields_to_replace: Dict) -> T:
+        raise NotImplemented()
+
+    async def delete(self, id: str):
+        raise NotImplemented()
+
+
+def get_table_class(
+    pydantic_class: type[BaseModel],
+) -> Tuple[type[TableInterface], type[BaseModel]]:
+
+    id_normalizer = get_surreal_id_fuckery_normalizer(pydantic_class.__name__)
+
+    class TableEntry(pydantic_class):
+        id: str
+
+    TableEntry.__name__ = pydantic_class.__name__
+    TableEntry.__doc__ = pydantic_class.__doc__
+
+    class Table(TableInterface):
+        __name = pydantic_class.__name__
+
+        def __init__(self, db_client: HTTPClient) -> None:
+            self._client = db_client
+
+        async def create(self, **data: Dict) -> TableEntry:
+            """Creates an object from kwargs with random id and stores it
+            in surrealdb"""
+            return TableEntry(
+                **(
+                    await self._client.create_all(
+                        self.__name, change_data_to_relation(data)
+                    )
+                )[0]
+            )
+
+        async def create_one(self, id: str, **data: Dict) -> TableEntry:
+            """Creates an object from kwargs with given id and stores it in
+            surrealdb"""
+            return TableEntry(
+                **await self._client.create_one(
+                    self.__name,
+                    id_normalizer(id),
+                    change_data_to_relation(data),
+                )
+            )
+
+        async def select(
+            self, where_args: str, where_params: Optional[Tuple] = None
+        ) -> List[TableEntry]:
+            """Returns rows that match the where clause"""
+            if where_params is None:
+                where_params = tuple()
+            else:
+                where_params = tuple([quote_param(param) for param in where_params])
+            return list(
+                TableEntry(**d)
+                for d in await self._client.execute(
+                    f"SELECT * FROM {self.__name} WHERE {where_args}".format(
+                        *where_params
+                    )
+                )
+            )
+
+        async def select_deep(self, id: str, fields_to_fetch: List[str]) -> TableEntry:
+            """Returns an object with given id with all it's links loaded"""
+            result = await self._client.execute(
+                f'SELECT * FROM {id} FETCH {",".join(fields_to_fetch)}'
+            )
+            if len(result) != 1:
+                raise Exception("Failed to fetch by id!")
+            return TableEntry(**result[0])
+
+        async def select_all(self) -> List[TableEntry]:
+            """Returns all rows from the table"""
+            response = await self._client.select_all(self.__name)
+            return list(TableEntry(**d) for d in response)
+
+        async def select_id(self, id: str) -> TableEntry:
+            """Selects a record with a given id"""
+            return TableEntry(
+                **await self._client.select_one(self.__name, id_normalizer(id))
+            )
+
+        async def replace(self, id: str, **new_data: Dict) -> TableEntry:
+            """Replaces all data with a given id with new id"""
+            return TableEntry(
+                **await self._client.replace_one(
+                    self.__name,
+                    id_normalizer(id),
+                    change_data_to_relation(new_data),
+                )
+            )
+
+        async def patch(self, id: str, **fields_to_replace: Dict) -> TableEntry:
+            """Patches some fields with a given id, a partial replace"""
+            return TableEntry(
+                **await self._client.upsert_one(
+                    self.__name,
+                    id_normalizer(id),
+                    change_data_to_relation(fields_to_replace),
+                )
+            )
+
+        async def delete(self, id: str):
+            """Deletes an item with a given id from the table"""
+            await self._client.delete_one(self.__name, id_normalizer(id))
+
+    # When debuging tables show the appropriate name
+    Table.__name__ = f"{pydantic_class.__name__}Table"
+
+    return Table, TableEntry
+
+
+def get_relation_class(
+    from_class: type[BaseModel],
+    to_class: type[BaseModel],
+    pydantic_class: type[BaseModel],
+) -> Tuple[type[RelationTableInterface], type[BaseModel]]:
+    class RelationEntry_proto(pydantic_class):
+        in_: Relation[from_class] = Field(alias="in")
+        out: Relation[to_class]
+
+    Table_class, RelationEntry = get_table_class(RelationEntry_proto)
+
+    class RelationTable(
+        Table_class,
+        RelationTableInterface[pydantic_class, from_class, to_class],
+    ):
+        __name = pydantic_class.__name__
+
+        async def create(
+            self,
+            from_obj: Union[from_class, str],
+            to_obj: Union[to_class, str],
+            **data: Dict,
+        ) -> RelationEntry:
+            res = await self._client.execute(
+                "RELATE {}->{}->{} CONTENT {}".format(
+                    from_obj if isinstance(from_obj, str) else from_obj.id,
+                    self.__name,
+                    to_obj if isinstance(to_obj, str) else to_obj.id,
+                    dumps(change_data_to_relation(data)),
+                ),
+            )
+            print(res)
+            if len(res) != 1:
+                raise Exception("Failed to create relation")
+            return RelationEntry(**res[0])
+
+    return RelationTable, RelationEntry

--- a/backend/app/surreal_orm/tables.py
+++ b/backend/app/surreal_orm/tables.py
@@ -1,12 +1,11 @@
 from surrealdb.common.json import dumps
 from pydantic import BaseModel, Field
-from surrealdb.clients import HTTPClient
+from surrealdb.clients import WebsocketClient
 from typing import Dict, Protocol, Tuple, Optional, List, TypeVar, Union
 
 from app.surreal_orm.relation import Relation
 from .utils import (
     change_data_to_relation,
-    get_surreal_id_fuckery_normalizer,
     quote_param,
     change_data_to_relation,
 )
@@ -109,8 +108,6 @@ def get_table_class(
     pydantic_class: type[BaseModel],
 ) -> Tuple[type[TableInterface], type[BaseModel]]:
 
-    id_normalizer = get_surreal_id_fuckery_normalizer(pydantic_class.__name__)
-
     class TableEntry(pydantic_class):
         id: str
 
@@ -120,29 +117,17 @@ def get_table_class(
     class Table(TableInterface):
         __name = pydantic_class.__name__
 
-        def __init__(self, db_client: HTTPClient) -> None:
+        def __init__(self, db_client: WebsocketClient) -> None:
             self._client = db_client
 
         async def create(self, **data: Dict) -> TableEntry:
             """Creates an object from kwargs with random id and stores it
             in surrealdb"""
-            return TableEntry(
-                **(
-                    await self._client.create_all(
+            result = await self._client.create(
                         self.__name, change_data_to_relation(data)
-                    )
-                )[0]
-            )
-
-        async def create_one(self, id: str, **data: Dict) -> TableEntry:
-            """Creates an object from kwargs with given id and stores it in
-            surrealdb"""
+                    ) 
             return TableEntry(
-                **await self._client.create_one(
-                    self.__name,
-                    id_normalizer(id),
-                    change_data_to_relation(data),
-                )
+                **result[0]
             )
 
         async def select(
@@ -162,22 +147,24 @@ def get_table_class(
                 fetch_statement = ""
             else:
                 fetch_statement = f"FETCH {', '.join(fields_to_fetch)}"
-            return list(
-                TableEntry(**d)
-                for d in await self._client.execute(
+            result = await self._client.query(
                     f"SELECT * FROM {self.__name} WHERE {where_args} {fetch_statement}".format(
                         *where_params
                     )
                 )
+            return list(
+                TableEntry(**d)
+                for d in result[0]
             )
 
         async def select_deep(
             self, id: str, fields_to_fetch: List[str]
         ) -> TableEntry:
             """Returns an object with given id with all it's links loaded"""
-            result = await self._client.execute(
+            result = await self._client.query(
                 f'SELECT * FROM {quote_param(id)} FETCH {",".join(fields_to_fetch)}'
             )
+            result = result[0]
             if len(result) != 1:
                 raise Exception("Failed to fetch by id!")
             return TableEntry(**result[0])
@@ -186,48 +173,50 @@ def get_table_class(
             """Selects given relations (edges) that come out of the given
             id"""
             # quote item id, to hopefully prevent SQL injection
-            item_id = quote_param(f"{self.__name}:{id_normalizer(id)}")
-            result = await self._client.execute(
+            item_id = quote_param(id)
+            result = await self._client.query(
                 f"SELECT ->{relation.__name__}.* AS rel FROM {item_id} FETCH rel.out"
             )
+            result = result[0]
             if len(result) != 1:
                 raise Exception("Failed to fetch by id!")
             return list(relation(**x) for x in result[0]["rel"])
 
         async def select_all(self) -> List[TableEntry]:
             """Returns all rows from the table"""
-            response = await self._client.select_all(self.__name)
+            response = await self._client.select(self.__name)
             return list(TableEntry(**d) for d in response)
 
         async def select_id(self, id: str) -> TableEntry:
             """Selects a record with a given id"""
+            res = await self._client.select(id)
             return TableEntry(
-                **await self._client.select_one(self.__name, id_normalizer(id))
+                **res[0]
             )
 
         async def replace(self, id: str, **new_data: Dict) -> TableEntry:
             """Replaces all data with a given id with new id"""
-            return TableEntry(
-                **await self._client.replace_one(
-                    self.__name,
-                    id_normalizer(id),
+            res = await self._client.update(
+                    id,
                     change_data_to_relation(new_data),
                 )
+            return TableEntry(
+                **res[0]
             )
 
         async def patch(self, id: str, **fields_to_replace: Dict) -> TableEntry:
             """Patches some fields with a given id, a partial replace"""
-            return TableEntry(
-                **await self._client.upsert_one(
-                    self.__name,
-                    id_normalizer(id),
+            res = await self._client.change(
+                    id,
                     change_data_to_relation(fields_to_replace),
                 )
+            return TableEntry(
+                **res[0]
             )
 
         async def delete(self, id: str):
             """Deletes an item with a given id from the table"""
-            await self._client.delete_one(self.__name, id_normalizer(id))
+            await self._client.delete(id)
 
     # When debugging tables show the appropriate name
     Table.__name__ = f"{pydantic_class.__name__}Table"
@@ -259,7 +248,7 @@ def get_relation_class(
             **data: Dict,
         ) -> RelationEntry:
             """Creates a relation using the `RELATE` statement"""
-            res = await self._client.execute(
+            res = await self._client.query(
                 "RELATE {}->{}->{} CONTENT {}".format(
                     quote_param(
                         from_obj if isinstance(from_obj, str) else from_obj.id
@@ -271,7 +260,7 @@ def get_relation_class(
                     dumps(change_data_to_relation(data)),
                 ),
             )
-            print(res)
+            res = res[0]
             if len(res) != 1:
                 raise Exception("Failed to create relation")
             return RelationEntry(**res[0])

--- a/backend/app/surreal_orm/utils.py
+++ b/backend/app/surreal_orm/utils.py
@@ -3,13 +3,11 @@ from typing import Any, Dict, Iterable
 from pydantic import BaseModel
 
 
-
-
 def change_data_to_relation(data: Dict) -> Dict:
     """
     Ensures that data is not duplicated and is instead related in the database
     """
-    
+
     def check_data(value: Any):
         """
         Recursively checks all fields for nested database entires and weird types

--- a/backend/app/surreal_orm/utils.py
+++ b/backend/app/surreal_orm/utils.py
@@ -43,7 +43,7 @@ def change_data_to_relation(data: Dict) -> Dict:
             # Value is a primitive, can be passed directly
             return value
         elif isinstance(value, BaseModel):
-            return {k: check_data(v) for k, v in value.dict()}
+            return {k: check_data(v) for k, v in value.dict(by_alias=True)}
         elif isinstance(value, Dict):
             return {k: check_data(v) for k, v in value.items()}
         elif isinstance(value, Iterable):

--- a/backend/app/surreal_orm/utils.py
+++ b/backend/app/surreal_orm/utils.py
@@ -24,13 +24,11 @@ def get_surreal_id_fuckery_normalizer(table_name: str):
     return normalizer
 
 
-@debug
 def change_data_to_relation(data: Dict) -> Dict:
     """
     Ensures that data is not duplicated and is instead related in the database
     """
 
-    @debug
     def check_data(value: Any):
         """
         Recursively checks all fields for nested database entires and weird types

--- a/backend/app/surreal_orm/utils.py
+++ b/backend/app/surreal_orm/utils.py
@@ -1,7 +1,67 @@
-from typing import Any
+from typing import Any, Dict, Iterable
+from surrealdb.models.link import RecordLink
+
+from pydantic import BaseModel
+
+from ..utils import debug
+
+
+def get_surreal_id_fuckery_normalizer(table_name: str):
+    """
+    surrealdb.py wants object ids without the table identifier when calling,
+    but always returns them in the results
+
+    This function returns a function that strips out the table
+    identifier/prefix from id if it is present
+    """
+    prefix = table_name + ":"
+
+    def normalizer(id: str) -> str:
+        if id.startswith(prefix):
+            return id[len(prefix) :]
+        return id
+
+    return normalizer
+
+
+@debug
+def change_data_to_relation(data: Dict) -> Dict:
+    """
+    Ensures that data is not duplicated and is instead related in the database
+    """
+
+    @debug
+    def check_data(value: Any):
+        """
+        Recursively checks all fields for nested database entires and weird types
+        """
+        if isinstance(value, BaseModel) and hasattr(value, "id"):
+            # Every pydantic class with an id is treated as a record in the
+            # database
+            return RecordLink(id=value.id)
+        elif any(isinstance(value, type) for type in [str, float, int, bool]):
+            # Value is a primitive, can be passed directly
+            return value
+        elif isinstance(value, BaseModel):
+            return {k: check_data(v) for k, v in value.dict()}
+        elif isinstance(value, Dict):
+            return {k: check_data(v) for k, v in value.items()}
+        elif isinstance(value, Iterable):
+            # If data is a listlike, then check all elements
+            return [check_data(v) for v in value]
+        else:
+            # Value is a weird, unhandled type
+            raise Exception(
+                f"Data type {type(value)} is not supported, try adding support for it"
+            )
+
+    return check_data(data)
 
 
 def quote_param(param: Any) -> str:
+    """
+    Quotes and serializes parameters for SurrealDB queries
+    """
     match param:
         case str():
             # Hopefully prevent SQL injection

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -1,13 +1,25 @@
-from typing import List
-from pydantic import BaseModel
+from typing import Dict
+from pydantic import BaseModel, Field
 
 from .surreal_orm.relation import RelationList
 from .surreal_orm import base
 
 
 @base.table
+class Node(BaseModel):
+    props: Dict
+
+
+@base.edge(Node, Node)
+class NodeRelation(BaseModel):
+    relation_type: str
+    props: Dict
+
+
+@base.table
 class Tree(BaseModel):
     name: str
+    nodes: RelationList[Node] = Field(default_factory=lambda: list())
 
 
 @base.table
@@ -18,4 +30,4 @@ class User(BaseModel):
     is_active: bool = True
     is_superuser: bool = False
     is_verified: bool = True
-    trees: RelationList[Tree]
+    trees: RelationList[Tree] = Field(default_factory=lambda: list())

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -1,5 +1,5 @@
-from typing import Dict
-from pydantic import BaseModel, Field
+from typing import Dict, Optional
+from pydantic import BaseModel
 
 from .surreal_orm.relation import RelationList
 from .surreal_orm import base
@@ -19,7 +19,7 @@ class NodeRelation(BaseModel):
 @base.table
 class Tree(BaseModel):
     name: str
-    nodes: RelationList[Node] = Field(default_factory=lambda: list())
+    nodes: RelationList[Node]
 
 
 @base.table
@@ -30,4 +30,4 @@ class User(BaseModel):
     is_active: bool = True
     is_superuser: bool = False
     is_verified: bool = True
-    trees: RelationList[Tree] = Field(default_factory=lambda: list())
+    trees: RelationList[Tree]

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -1,0 +1,21 @@
+from typing import List
+from pydantic import BaseModel
+
+from .surreal_orm.relation import RelationList
+from .surreal_orm import base
+
+
+@base.table
+class Tree(BaseModel):
+    name: str
+
+
+@base.table
+class User(BaseModel):
+    id: str
+    email: str
+    hashed_password: str
+    is_active: bool = True
+    is_superuser: bool = False
+    is_verified: bool = True
+    trees: RelationList[Tree]

--- a/backend/app/trees.py
+++ b/backend/app/trees.py
@@ -20,8 +20,9 @@ def get_tree_router(fastapi_users: FastAPIUsers) -> APIRouter:
         user: UserRead = Depends(fastapi_users.current_user()),
         session: Session = Depends(get_db),
     ):
-        tree = await session.Tree.create(name=name)
+        tree = await session.Tree.create(name=name, nodes=[])
         await session.User.patch(user.id, trees=[*user.trees, tree])
+        await session.commit()
         return tree
 
     @router.get("/my", response_model=List[Tree])

--- a/backend/app/trees.py
+++ b/backend/app/trees.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi_users import FastAPIUsers
 
 from app.surreal_orm.session import Session
@@ -30,5 +30,15 @@ def get_tree_router(fastapi_users: FastAPIUsers) -> APIRouter:
         session: Session = Depends(get_db),
     ):
         return (await session.User.select_deep(user.id, ["trees"])).trees
+
+    @router.get("/{tree_id}", response_model=Tree)
+    async def get_detailed_tree(
+        tree_id: str,
+        current_user: UserRead = Depends(fastapi_users.current_user()),
+        session: Session = Depends(get_db),
+    ):
+        if tree_id not in current_user.trees:
+            raise HTTPException(403)
+        return await session.Tree.select_deep(tree_id, ["nodes"])
 
     return router

--- a/backend/app/trees.py
+++ b/backend/app/trees.py
@@ -1,0 +1,34 @@
+from typing import List
+from fastapi import APIRouter, Depends
+from fastapi_users import FastAPIUsers
+
+from app.surreal_orm.session import Session
+from app.utils import debug
+
+from .surreal_orm import get_db
+
+from .users import UserRead
+from .tables import Tree
+
+
+def get_tree_router(fastapi_users: FastAPIUsers) -> APIRouter:
+    router = APIRouter()
+
+    @router.post("/new", response_model=Tree)
+    async def create_new_tree(
+        name: str,
+        user: UserRead = Depends(fastapi_users.current_user()),
+        session: Session = Depends(get_db),
+    ):
+        tree = await session.Tree.create(name=name)
+        await session.User.patch(user.id, trees=[*user.trees, tree])
+        return tree
+
+    @router.get("/my", response_model=List[Tree])
+    async def list_my_trees(
+        user: UserRead = Depends(fastapi_users.current_user()),
+        session: Session = Depends(get_db),
+    ):
+        return (await session.User.select_deep(user.id, ["trees"])).trees
+
+    return router

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import List, Optional, Dict
 from fastapi import Depends, Request
 from fastapi_users import schemas, BaseUserManager, FastAPIUsers
 from fastapi_users.db.base import BaseUserDatabase
@@ -7,23 +7,13 @@ from fastapi_users.authentication import (
     BearerTransport,
     JWTStrategy,
 )
-from pydantic import BaseModel
+from .tables import User
 
-from .surreal_orm import base, Session, get_db
-
-
-@base.table
-class User(BaseModel):
-    id: str
-    email: str
-    hashed_password: str
-    is_active: bool = True
-    is_superuser: bool = False
-    is_verified: bool = True
+from .surreal_orm import Session, get_db
 
 
 class UserRead(schemas.BaseUser):
-    pass
+    trees: List[str]
 
 
 class UserCreate(schemas.BaseUserCreate):
@@ -93,9 +83,7 @@ class UserManager(BaseUserManager[User, str]):
         self, user: User, token: str, _: Optional[Request] = None
     ):
         # TODO: Send verification token via email?
-        print(
-            f"Verification requested for user {user.id}. Verification token: {token}"
-        )
+        print(f"Verification requested for user {user.id}. Verification token: {token}")
 
 
 async def get_user_manager(

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -49,7 +49,7 @@ class SurrealUsersDatabase(BaseUserDatabase[User, str]):
     async def create(self, create_dict: Dict) -> User:
         res = await self._session.User.create(**create_dict, trees=[])
         await self._session.commit()
-        return res 
+        return res
 
     async def update(self, user: User, update_dict: Dict) -> User:
         res = await self._session.User.patch(user.id, **update_dict)

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -83,7 +83,9 @@ class UserManager(BaseUserManager[User, str]):
         self, user: User, token: str, _: Optional[Request] = None
     ):
         # TODO: Send verification token via email?
-        print(f"Verification requested for user {user.id}. Verification token: {token}")
+        print(
+            f"Verification requested for user {user.id}. Verification token: {token}"
+        )
 
 
 async def get_user_manager(

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,37 @@
+from typing import Callable
+from inspect import iscoroutinefunction
+from functools import wraps
+
+
+def debug(f: Callable):
+    if iscoroutinefunction(f):
+
+        @wraps(f)
+        async def innerAsync(*args, **kwargs):
+            res = await f(*args, **kwargs)
+            print(
+                f"f: {f.__name__}:",
+                f"{repr(args)}",
+                f"& {repr(kwargs)}",
+                f"-> {repr(res)}",
+                sep="\t",
+                flush=True,
+            )
+            return res
+
+        return innerAsync
+
+    @wraps(f)
+    def inner(*args, **kwargs):
+        res = f(*args, **kwargs)
+        print(
+            f"f: {f.__name__}:",
+            f"{repr(args)}",
+            f"& {repr(kwargs)}",
+            f"-> {repr(res)}",
+            sep="\t",
+            flush=True,
+        )
+        return res
+
+    return inner

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -476,7 +476,7 @@ speedups = []
 type = "git"
 url = "https://github.com/HakierGrzonzo/surrealdb.py"
 reference = "HEAD"
-resolved_reference = "5d05e47e277f4abdaeb265f5e3fe8f2229c088e6"
+resolved_reference = "60d80006f1033ebc7735f2ebe7f59a9de6fdbfe6"
 
 [[package]]
 name = "tomli"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -474,9 +474,9 @@ speedups = []
 
 [package.source]
 type = "git"
-url = "https://github.com/HakierGrzonzo/surrealdb.py.git"
+url = "https://github.com/HakierGrzonzo/surrealdb.py"
 reference = "HEAD"
-resolved_reference = "6df7aaca2e49dafdd4982c9ea9260238bd627b62"
+resolved_reference = "5d05e47e277f4abdaeb265f5e3fe8f2229c088e6"
 
 [[package]]
 name = "tomli"
@@ -524,7 +524,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "196fadee68111980ba7427b7fa263b31835a889ce53cdb38873850a093734746"
+content-hash = "7760b81a89d572b76bcb2f3bcf8134a99c61a58a6bd7476353921e1861b2f4ff"
 
 [metadata.files]
 aiohttp = [

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -66,7 +66,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "bcrypt"
@@ -129,7 +129,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -338,7 +338,7 @@ bcrypt = {version = ">=3.1.0", optional = true, markers = "extra == \"bcrypt\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=18.2.0)"]
 bcrypt = ["bcrypt (>=3.1.0)"]
-build_docs = ["cloud-sptheme (>=1.10.1)", "sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)"]
+build-docs = ["cloud-sptheme (>=1.10.1)", "sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)"]
 totp = ["cryptography"]
 
 [[package]]
@@ -474,9 +474,9 @@ speedups = []
 
 [package.source]
 type = "git"
-url = "https://github.com/surrealdb/surrealdb.py.git"
+url = "https://github.com/HakierGrzonzo/surrealdb.py.git"
 reference = "HEAD"
-resolved_reference = "f3550eed0bfe82c1af1a8fcc64c203b634f53596"
+resolved_reference = "6df7aaca2e49dafdd4982c9ea9260238bd627b62"
 
 [[package]]
 name = "tomli"
@@ -524,7 +524,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "578576063825822400a715ae7d70858731a1d357212fde281395b0099d06cd83"
+content-hash = "196fadee68111980ba7427b7fa263b31835a889ce53cdb38873850a093734746"
 
 [metadata.files]
 aiohttp = [
@@ -647,14 +647,23 @@ bcrypt = [
     {file = "bcrypt-4.0.0.tar.gz", hash = "sha256:c59c170fc9225faad04dde1ba61d85b413946e8ce2e5f5f5ff30dfd67283f319"},
 ]
 black = [
+    {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
+    {file = "black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef"},
+    {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
+    {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
+    {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
+    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
     {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
     {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
+    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
     {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
     {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
     {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
     {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
+    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
     {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
     {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
+    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
     {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
     {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = "^3.10"
 fastapi = "^0.85.0"
 fastapi-users = "^10.1.5"
-surrealdb = {git = "https://github.com/surrealdb/surrealdb.py.git"}
+surrealdb = {git = "https://github.com/HakierGrzonzo/surrealdb.py.git"}
 uvicorn = "^0.18.3"
 
 [tool.poetry.group.dev.dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 python = "^3.10"
 fastapi = "^0.85.0"
 fastapi-users = "^10.1.5"
-surrealdb = {git = "https://github.com/HakierGrzonzo/surrealdb.py.git"}
 uvicorn = "^0.18.3"
+surrealdb = {git = "https://github.com/HakierGrzonzo/surrealdb.py"}
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.10.0"


### PR DESCRIPTION
**Prace wrą, jeszcze więcej ficzerów dla `edge` trzeba wyklepać**

# Co zostało zrobione:

- Wsparcie dla prostych relacji `record-link`
- Wsparcie dla skompilowanych relacji `edge`
- Zalążki `CRUD`
- Migracja na klienta websocket
- Przyszłe wsparcie dla transakcji (które jest broken)


# Na co należy zwrócić uwagę:

- Przykładowe trasy
- README dla surreal_orm
