### PR TITLE
Strona startowa + ciasteczkowy popup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,7 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
       -
         name: Docker meta
         id: meta
@@ -36,19 +37,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile.frontend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   backend:
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
         uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
       -
         name: Docker meta
         id: meta
@@ -76,13 +80,15 @@ jobs:
         run: echo ${{ steps.get_version.outputs.version-without-v }} > ./backend/backend/.version
       -
         name: Build and push fastapi
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile.backend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deployment:
     if: github.ref_name == 'main'

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,13 +1,5 @@
-import {
-  Alert,
-  AlertTitle,
-  Box,
-  createTheme,
-  CssBaseline,
-  ThemeProvider,
-  Typography,
-} from "@mui/material";
-import type { MetaFunction } from "@remix-run/node";
+import { createTheme, CssBaseline, ThemeProvider } from "@mui/material";
+import { Headers, LoaderFunction, MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -16,10 +8,11 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
+import CookieConsent from "src/components/CookieConsent";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
-  title: "Kronikarz tool for chronology tree",
+  title: "Kronikarz",
   viewport: "width=device-width,initial-scale=1",
 });
 
@@ -27,7 +20,6 @@ export default function App() {
   const theme = createTheme({
     palette: {
       primary: {
-        // main: "#65B2A3",
         main: "#A08D8D",
       },
       secondary: {
@@ -49,37 +41,21 @@ export default function App() {
           href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
         />
       </head>
-      <body>
+      <body
+        style={{
+          height: "100vh",
+          backgroundColor: theme.palette.background.default,
+        }}
+      >
         <CssBaseline />
         <ThemeProvider theme={theme}>
           <Outlet />
+          <CookieConsent />
         </ThemeProvider>
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
       </body>
     </html>
-  );
-}
-
-export function CatchBoundary() {
-  return (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        height: "100vh",
-        width: "100vw",
-        justifyContent: "center",
-      }}
-    >
-      <Alert severity="error" sx={{ width: "15cm" }}>
-        <AlertTitle>You don't have permission to access this page!</AlertTitle>
-        <Typography variant="body1">
-          You don't have permissions to access this page, please contact your
-          supervisor if those permissions are necessary for your work.
-        </Typography>
-      </Alert>
-    </Box>
   );
 }

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -1,4 +1,43 @@
-import type { LoaderFunction } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
+import { AppBar, Box, Card, Typography, Button, Divider } from "@mui/material";
+import { Link } from "@remix-run/react";
+import { MetaFunction } from "@remix-run/node";
 
-export const loader: LoaderFunction = () => redirect("/login", 301);
+export const meta: MetaFunction = () => ({
+  title: "Kronikarz: free tool for family trees",
+});
+
+export default function () {
+  return (
+    <Box
+      sx={{
+        maxHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+      }}
+    >
+      <img
+        src="/logo.png"
+        alt="Kronikarz logo"
+        style={{ maxHeight: "80vh", width: "auto" }}
+      />
+      <Box
+        sx={{
+          display: "grid",
+          padding: 1,
+          gap: 4,
+          gridTemplateColumns: "1fr 1fr",
+          maxWidth: "10cm",
+          justifyContent: "space-around",
+        }}
+      >
+        <Button sx={{ fontSize: "150%" }} variant="contained" href="/login">
+          Login
+        </Button>
+        <Button sx={{ fontSize: "150%" }} variant="contained" href="/register">
+          Register
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -42,7 +42,6 @@ export default function Login() {
           backgroundRepeat: "no-repeat",
           backgroundPosition: "center",
           backgroundSize: "contain",
-          backgroundColor: "#e0edf2",
         }}
       >
         <Form method="post">
@@ -52,6 +51,7 @@ export default function Login() {
               flexDirection: "row",
               justifyContent: "space-evenly",
               alignItems: "center",
+              gap: 1,
               width: "60vw",
               marginTop: "500px",
               marginLeft: "26px",

--- a/frontend/src/components/CookieConsent.tsx
+++ b/frontend/src/components/CookieConsent.tsx
@@ -1,0 +1,49 @@
+import {
+  Modal,
+  Typography,
+  Card,
+  Divider,
+  CardActions,
+  CardContent,
+  Button,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+
+export default function CookieConsent() {
+  const [cookieConsent, setCookieConsent] = useState<boolean>(false);
+  useEffect(() => {
+    const rawCookieConsent = localStorage.getItem("cookieConsent");
+    if (rawCookieConsent) {
+      // If there is a value, then we must have set it to true
+      setCookieConsent(true);
+    }
+  }, [setCookieConsent]);
+
+  const cookieAccept = () => {
+    localStorage.setItem("cookieConsent", "yes");
+    setCookieConsent(true);
+  };
+
+  return (
+    <Modal open={!cookieConsent}>
+      <Card
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          padding: 1,
+        }}
+      >
+        <CardContent>
+          <Typography variant="h1">Cookies</Typography>
+          <Divider />
+          <Typography variant="body1">We use cookies</Typography>
+        </CardContent>
+        <CardActions>
+          <Button onClick={cookieAccept}>Accept</Button>
+        </CardActions>
+      </Card>
+    </Modal>
+  );
+}


### PR DESCRIPTION
# Co zostało zrobione:

- Dodano stronę startową
- Dodano modal ciasteczkowy
  - Renderowanie wyłącznie na kliencie + zapis w localstorage
- Buildowanie apki ma cache dla dockera, nie będzie się musiało robić npm install zawsze

# Na co należy zwrócić uwagę:

- Przyciski z MUI dałem
